### PR TITLE
update: nvngx_dlss to 3.7.10

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -18,7 +18,7 @@ namespace RDR2_DLSS_Replacer
         public const string PROCESS_NAME = "RDR2";
 
         public const string DLSS_TO_USE = "nvngx_dlss.dll";
-        public const string DLSS_TO_DOWNLOAD_IF_NOT_FOUND = "https://github.com/Bullz3y3/RDR2_DLSS_Replacer/raw/master/DLSS/nvngx_dlss_3.5.10.dll";
+        public const string DLSS_TO_DOWNLOAD_IF_NOT_FOUND = "https://github.com/Bullz3y3/RDR2_DLSS_Replacer/raw/master/DLSS/nvngx_dlss_3.7.10.dll";
         public const string DLSS_DOWNLOAD_PROGRESS_STRING = "Please wait... downloading: ";
 
         public const string DLSS_FILE_TO_REPLACE_IN_RDR2_LOCATION = "nvngx_dlss.dll";

--- a/RDR2_DLSS_Replacer.csproj
+++ b/RDR2_DLSS_Replacer.csproj
@@ -72,7 +72,7 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="DLSS\nvngx_dlss_2.5.1.0.dll" />
-    <Content Include="DLSS\nvngx_dlss_3.5.10.dll" />
+    <Content Include="DLSS\nvngx_dlss_3.7.10.dll" />
     <Content Include="rdr2_location_for_auto_start.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Run it before launching RDR2, it will replace DLSS with your preferred version, 
 3. Run `RDR2_DLSS_Replacer.exe`
    - It needs Administrator Privileges to replace `nvngx_dlss.dll` in RDR2 directory.
    - It requires .NET Framework 4.7.2+ installed. [Download from Microsoft.](https://dotnet.microsoft.com/en-us/download/dotnet-framework/thank-you/net472-offline-installer)
-   - It will download DLSS/nvngx_dlss_3.5.10.dll automatically when you run it for the first time. 
+   - It will download DLSS/nvngx_dlss_3.7.10.dll automatically when you run it for the first time. 
      - (Optional) If you want to use your own preferred DLSS file then paste it in the folder of RDR2_DLSS_Replacer.exe and name it as nvngx_dlss.dll
 4. Start Red Dead Redemption 2 game.
 


### PR DESCRIPTION
This uses the new DLSS 3.7.10 version instead of current 3.5.10

According to [TechPowerUp](https://www.techpowerup.com/321209/nvidia-releases-dlss-3-7-0-with-quality-e-preset-for-image-quality-improvements), it uses a new default preset which delivers better motion handling.

The article is about 3.7.0 but this is roughly the same: 3.7.10 is a bug fix release.